### PR TITLE
fix bellmanford

### DIFF
--- a/graph/shortest_path/bellmanford.hpp
+++ b/graph/shortest_path/bellmanford.hpp
@@ -19,6 +19,9 @@ pair<vc<T>, vc<int>> BellmanFord(GT& G, int s) {
       for (auto&& e: G[v]) {
         T before = dist[e.to];
         T after = dist[v] + e.cost;
+        if (dist[v] == -infty<T>) {
+          after = -infty<T>;
+        }
         chmax(after, -infty<T>);
         if (before > after) {
           par[e.to] = v;


### PR DESCRIPTION
負閉路が存在して-infty >= (N-1) * (1 stepで伝搬する最小値)の時に壊れる可能性があります。

例 (簡単のためinftyを小さくしています。)
N = 100
infty = 100
0 <= i <= 97について i -> i + 1に コスト-1の辺。
98 -> 99にコスト1の辺。
99 -> 0にコスト-1の辺。
が貼られているとします。
最後に更新されるのは3ステップ目で、
dist[99] = -100になって欲しいですが、dist[99] = -99で止まってしまいます。 この場合は辺を昇順に見ていくと1ステップでの変化量が最小で-98
となりますから、-infty >= (N-1) * -98のときNステップ未満で終了してしまい正しく求まらない可能性があります。 inplaceに更新すると64bitでもinftyが足りない可能性があります。