### PR TITLE
Fix node initialization in dynamic segment trees

### DIFF
--- a/ds/segtree/dynamic_lazy_segtree.hpp
+++ b/ds/segtree/dynamic_lazy_segtree.hpp
@@ -168,8 +168,8 @@ private:
     }
     // push
     ll m = (l + r) / 2;
-    c->l = (c->l ? copy_node(c->l) : new_node());
-    c->r = (c->r ? copy_node(c->r) : new_node());
+    c->l = (c->l ? copy_node(c->l) : new_node(m - l));
+    c->r = (c->r ? copy_node(c->r) : new_node(r - m));
     c->l->x = AM::act(c->l->x, c->lazy, m - l);
     c->l->lazy = MA::op(c->l->lazy, c->lazy);
     c->r->x = AM::act(c->r->x, c->lazy, r - m);

--- a/ds/segtree/dynamic_segtree.hpp
+++ b/ds/segtree/dynamic_segtree.hpp
@@ -126,11 +126,11 @@ private:
     }
     ll m = (l + r) / 2;
     if (l <= i && i < m) {
-      c->l = (c->l ? copy_node(c->l) : new_node());
+      c->l = (c->l ? copy_node(c->l) : new_node(m - l));
       set_rec(c->l, l, m, i, x);
     }
     if (m <= i && i < r) {
-      c->r = (c->r ? copy_node(c->r) : new_node());
+      c->r = (c->r ? copy_node(c->r) : new_node(r - m));
       set_rec(c->r, m, r, i, x);
     }
     X xl = (c->l ? c->l->x : default_prod(l, m));
@@ -148,11 +148,11 @@ private:
     }
     ll m = (l + r) / 2;
     if (l <= i && i < m) {
-      c->l = (c->l ? copy_node(c->l) : new_node());
+      c->l = (c->l ? copy_node(c->l) : new_node(m - l));
       multiply_rec(c->l, l, m, i, x);
     }
     if (m <= i && i < r) {
-      c->r = (c->r ? copy_node(c->r) : new_node());
+      c->r = (c->r ? copy_node(c->r) : new_node(r - m));
       multiply_rec(c->r, m, r, i, x);
     }
     X xl = (c->l ? c->l->x : default_prod(l, m));


### PR DESCRIPTION
以下のように `new_node` で区間長の指定は必要ではないかと思います:

```diff
-    c->l = (c->l ? copy_node(c->l) : new_node());
-    c->r = (c->r ? copy_node(c->r) : new_node());
+    c->l = (c->l ? copy_node(c->l) : new_node(m - l));
+    c->r = (c->r ? copy_node(c->r) : new_node(r - m));
```

> ※ 特に実際の動作確認はできておりません。すみません。

関連のテストでは `ActedMonoid_Sum_Assign` を使っていたため、 `Mx::op` のタイミングで `x` が正常な値に上書きされたと思います。関連のテストは以下です (`rg Dyn | rg '\->'` で見つけました):

- test/1_mytest/dynamic_lazy_segtree_persistent.test.cpp
  変更後も AC しました
- test/3_yukicoder/2292.test.cpp
  すみません、動作未確認です
- test/1_mytest/dynamic_lazy_segtree.test.cpp
  変更後も AC しました
